### PR TITLE
Clarify documentation for service name and type in `edge-mdns`

### DIFF
--- a/edge-mdns/src/host.rs
+++ b/edge-mdns/src/host.rs
@@ -77,7 +77,7 @@ impl HostAnswers for Host<'_> {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Service<'a> {
-    /// The name of the service.
+    /// The name of the service. I.e. "printer"
     pub name: &'a str,
     /// The priority of the service.
     pub priority: u16,


### PR DESCRIPTION
This PR fixes #76 

I have used `edge_net` as service name and type because it is easy to understand immediately