### PR TITLE
Erase the const generics from the edge-nal-embassy types

### DIFF
--- a/edge-nal-embassy/CHANGELOG.md
+++ b/edge-nal-embassy/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Erase the const generics from the edge-nal-embassy types #78
+* Make `Tcp`, `Udp` and `Dns` `Copy`
+
 ## [0.6.0] - 2025-05-29
 * Optional `defmt` support via two new features (one has to specify one, or the other, or neither, but not both):
   * `log` - uses the `log` crate for all logging

--- a/edge-nal-embassy/CHANGELOG.md
+++ b/edge-nal-embassy/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 * Erase the const generics from the edge-nal-embassy types #78
 * Make `Tcp`, `Udp` and `Dns` `Copy`
-
+* Change the TX_SZ and RX_SZ defaults for UDP buffers to 1472 bytes which is a bit smaller yet enough if the overall Ethernet MTU is 1500 bytes (which it typically is; Ethernet MTU might be lower, but is rarely higher)
 ## [0.6.0] - 2025-05-29
 * Optional `defmt` support via two new features (one has to specify one, or the other, or neither, but not both):
   * `log` - uses the `log` crate for all logging

--- a/edge-nal-embassy/src/dns.rs
+++ b/edge-nal-embassy/src/dns.rs
@@ -2,13 +2,16 @@ use core::net::IpAddr;
 
 use edge_nal::AddrType;
 
-use embassy_net::{
-    dns::{DnsQueryType, Error},
-    Stack,
-};
+use embassy_net::dns::{DnsQueryType, Error};
+use embassy_net::Stack;
+
 use embedded_io_async::ErrorKind;
 
-/// A struct that implements the `Dns` trait from `edge-nal`
+/// A type that implements the `Dns` trait from `edge-nal`.
+/// It uses the DNS resolver from the provided Embassy networking stack.
+///
+/// The type is `Copy` and `Clone`, so it can be easily passed around.
+#[derive(Copy, Clone)]
 pub struct Dns<'a> {
     stack: Stack<'a>,
 }
@@ -51,6 +54,7 @@ impl edge_nal::Dns for Dns<'_> {
     }
 }
 
+/// DNS error type
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DnsError(Error);
@@ -61,7 +65,6 @@ impl From<Error> for DnsError {
     }
 }
 
-// TODO
 impl embedded_io_async::Error for DnsError {
     fn kind(&self) -> ErrorKind {
         ErrorKind::Other

--- a/edge-nal-embassy/src/lib.rs
+++ b/edge-nal-embassy/src/lib.rs
@@ -18,6 +18,8 @@ pub use tcp::*;
 #[cfg(feature = "udp")]
 pub use udp::*;
 
+use crate::sealed::SealedDynPool;
+
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
@@ -28,7 +30,44 @@ mod tcp;
 #[cfg(feature = "udp")]
 mod udp;
 
-pub(crate) struct Pool<T, const N: usize> {
+/// A const-generics-erased trait variant of `Pool`
+///
+/// Allows for types like `Tcp`, `TcpSocket`, `Udp` and `UdpSocket` that do reference the
+/// pool to erase the const-genenerics set on the Pool object type when used for TCP and UDP buffers.
+///
+/// To erase the type of the pool itself, these types use `&dyn DynPool<B>`
+pub trait DynPool<B>: SealedDynPool<B> {}
+
+impl<T, B> DynPool<B> for &T where T: DynPool<B> {}
+
+mod sealed {
+    /// The sealed trait variant of `DynPool`.
+    pub trait SealedDynPool<B> {
+        /// Allocate an object from the pool.
+        ///
+        /// Returns `None` if the pool is exhausted.
+        fn alloc(&self) -> Option<B>;
+
+        /// Free an object back to the pool.
+        fn free(&self, buffer: B);
+    }
+
+    impl<T, B> SealedDynPool<B> for &T
+    where
+        T: SealedDynPool<B>,
+    {
+        fn alloc(&self) -> Option<B> {
+            (**self).alloc()
+        }
+
+        fn free(&self, buffer: B) {
+            (**self).free(buffer)
+        }
+    }
+}
+
+/// A simple fixed-size pool allocator for `T`.
+pub struct Pool<T, const N: usize> {
     used: [Cell<bool>; N],
     data: [UnsafeCell<MaybeUninit<T>>; N],
 }
@@ -39,7 +78,8 @@ impl<T, const N: usize> Pool<T, N> {
     #[allow(clippy::declare_interior_mutable_const)]
     const UNINIT: UnsafeCell<MaybeUninit<T>> = UnsafeCell::new(MaybeUninit::uninit());
 
-    const fn new() -> Self {
+    /// Create a new pool.
+    pub const fn new() -> Self {
         Self {
             used: [Self::VALUE; N],
             data: [Self::UNINIT; N],
@@ -48,6 +88,11 @@ impl<T, const N: usize> Pool<T, N> {
 }
 
 impl<T, const N: usize> Pool<T, N> {
+    /// Allocate an object from the pool.
+    ///
+    /// # Returns
+    /// - `Some(NonNull<T>)` if an object was successfully allocated.
+    /// - `None` if the pool is exhausted.
     fn alloc(&self) -> Option<NonNull<T>> {
         for n in 0..N {
             // this can't race because Pool is not Sync.
@@ -60,7 +105,12 @@ impl<T, const N: usize> Pool<T, N> {
         None
     }
 
-    /// safety: p must be a pointer obtained from self.alloc that hasn't been freed yet.
+    /// Free an object back to the pool.
+    ///
+    /// Safety: p must be a pointer obtained from `alloc` that hasn't been freed yet.
+    ///
+    /// # Arguments
+    /// - `p`: A pointer to the object to free.
     unsafe fn free(&self, p: NonNull<T>) {
         let origin = self.data.as_ptr() as *mut T;
         let n = p.as_ptr().offset_from(origin);
@@ -70,10 +120,12 @@ impl<T, const N: usize> Pool<T, N> {
     }
 }
 
+/// Convert an embassy-net `IpEndpoint` to a standard library `SocketAddr`.
 pub(crate) fn to_net_socket(socket: IpEndpoint) -> SocketAddr {
     SocketAddr::new(socket.addr.into(), socket.port)
 }
 
+/// Convert an embassy-net `IpListenEndpoint` to a standard library `SocketAddr`.
 pub(crate) fn to_emb_socket(socket: SocketAddr) -> Option<IpEndpoint> {
     Some(IpEndpoint {
         addr: to_emb_addr(socket.ip())?,
@@ -81,6 +133,7 @@ pub(crate) fn to_emb_socket(socket: SocketAddr) -> Option<IpEndpoint> {
     })
 }
 
+/// Convert a standard library `SocketAddr` to an embassy-net `IpListenEndpoint`.
 pub(crate) fn to_emb_bind_socket(socket: SocketAddr) -> Option<IpListenEndpoint> {
     let addr = if socket.ip().is_unspecified() {
         None
@@ -94,6 +147,7 @@ pub(crate) fn to_emb_bind_socket(socket: SocketAddr) -> Option<IpListenEndpoint>
     })
 }
 
+/// Convert an embassy-net `IpAddress` to a standard library `IpAddr`.
 pub(crate) fn to_emb_addr(addr: IpAddr) -> Option<IpAddress> {
     match addr {
         #[cfg(feature = "proto-ipv4")]

--- a/edge-nal-embassy/src/lib.rs
+++ b/edge-nal-embassy/src/lib.rs
@@ -33,7 +33,7 @@ mod udp;
 /// A const-generics-erased trait variant of `Pool`
 ///
 /// Allows for types like `Tcp`, `TcpSocket`, `Udp` and `UdpSocket` that do reference the
-/// pool to erase the const-genenerics set on the Pool object type when used for TCP and UDP buffers.
+/// pool to erase the const-generics set on the Pool object type when used for TCP and UDP buffers.
 ///
 /// To erase the type of the pool itself, these types use `&dyn DynPool<B>`
 pub trait DynPool<B>: SealedDynPool<B> {}

--- a/edge-nal-embassy/src/tcp.rs
+++ b/edge-nal-embassy/src/tcp.rs
@@ -11,33 +11,40 @@ use embassy_net::Stack;
 
 use embedded_io_async::{ErrorKind, ErrorType, Read, Write};
 
-use crate::{to_emb_bind_socket, to_emb_socket, to_net_socket, Pool};
+use crate::sealed::SealedDynPool;
+use crate::{to_emb_bind_socket, to_emb_socket, to_net_socket, DynPool, Pool};
 
-/// A struct that implements the `TcpConnect` and `TcpBind` factory traits from `edge-nal`
-/// Capable of managing up to N concurrent connections with TX and RX buffers according to TX_SZ and RX_SZ.
-pub struct Tcp<'d, const N: usize, const TX_SZ: usize = 1024, const RX_SZ: usize = 1024> {
+/// A type that implements the `TcpConnect` and `TcpBind` factory traits from `edge-nal`
+/// Uses the provided Embassy networking stack and TCP buffers pool to create TCP sockets.
+///
+/// The type is `Copy` and `Clone`, so it can be easily passed around.
+#[derive(Copy, Clone)]
+pub struct Tcp<'d> {
+    /// The Embassy networking stack to use for creating TCP sockets.
     stack: Stack<'d>,
-    buffers: &'d TcpBuffers<N, TX_SZ, RX_SZ>,
+    /// The pool of TCP socket buffers to use for creating TCP sockets.
+    buffers: &'d dyn DynPool<TcpSocketBuffers>,
 }
 
-impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> Tcp<'d, N, TX_SZ, RX_SZ> {
-    /// Create a new `Tcp` instance for the provided Embassy networking stack, using the provided TCP buffers
+impl<'d> Tcp<'d> {
+    /// Create a new `Tcp` instance for the provided Embassy networking stack, using the provided TCP buffers.
     ///
-    /// Ensure that the number of buffers `N` fits within StackResources<N> of
-    /// [embassy_net::Stack], while taking into account the sockets used for DHCP, DNS, etc. else
-    /// [smoltcp::iface::SocketSet] will panic with `adding a socket to a full SocketSet`.
-    pub fn new(stack: Stack<'d>, buffers: &'d TcpBuffers<N, TX_SZ, RX_SZ>) -> Self {
+    /// # Arguments
+    /// - `stack`: The Embassy networking stack to use for creating TCP sockets.
+    /// - `buffers`: A reference to a pool of TCP socket buffers.
+    ///   NOTE: Ensure that the number of buffers in the pool is not greater than the number of sockets
+    ///   supported by the provided [embassy_net::Stack], or else [smoltcp::iface::SocketSet] will panic with
+    ///   `adding a socket to a full SocketSet`.
+    pub fn new(stack: Stack<'d>, buffers: &'d dyn DynPool<TcpSocketBuffers>) -> Self {
         Self { stack, buffers }
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpConnect
-    for Tcp<'_, N, TX_SZ, RX_SZ>
-{
+impl TcpConnect for Tcp<'_> {
     type Error = TcpError;
 
     type Socket<'a>
-        = TcpSocket<'a, N, TX_SZ, RX_SZ>
+        = TcpSocket<'a>
     where
         Self: 'a;
 
@@ -53,32 +60,37 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpConnect
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpBind for Tcp<'_, N, TX_SZ, RX_SZ> {
+impl TcpBind for Tcp<'_> {
     type Error = TcpError;
 
     type Accept<'a>
-        = TcpAccept<'a, N, TX_SZ, RX_SZ>
+        = TcpAccept<'a>
     where
         Self: 'a;
 
     async fn bind(&self, local: SocketAddr) -> Result<Self::Accept<'_>, Self::Error> {
-        Ok(TcpAccept { stack: self, local })
+        Ok(TcpAccept {
+            stack: *self,
+            local,
+        })
     }
 }
 
-/// Represents an acceptor for incoming TCP client connections. Implements the `TcpAccept` factory trait from `edge-nal`
-pub struct TcpAccept<'d, const N: usize, const TX_SZ: usize = 1024, const RX_SZ: usize = 1024> {
-    stack: &'d Tcp<'d, N, TX_SZ, RX_SZ>,
+/// A type that represents an acceptor for incoming TCP client connections.
+/// Implements the `TcpAccept` factory trait from `edge-nal`
+///
+/// The type is `Copy` and `Clone`, so it can be easily passed around.
+#[derive(Copy, Clone)]
+pub struct TcpAccept<'d> {
+    stack: Tcp<'d>,
     local: SocketAddr,
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> edge_nal::TcpAccept
-    for TcpAccept<'_, N, TX_SZ, RX_SZ>
-{
+impl edge_nal::TcpAccept for TcpAccept<'_> {
     type Error = TcpError;
 
     type Socket<'a>
-        = TcpSocket<'a, N, TX_SZ, RX_SZ>
+        = TcpSocket<'a>
     where
         Self: 'a;
 
@@ -96,31 +108,39 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> edge_nal::TcpAccept
     }
 }
 
-/// A TCP socket
+/// A type that represents a TCP socket
 /// Implements the `Read` and `Write` traits from `embedded-io-async`, as well as the `TcpSplit` factory trait from `edge-nal`
-pub struct TcpSocket<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> {
+pub struct TcpSocket<'d> {
     socket: embassy_net::tcp::TcpSocket<'d>,
-    stack_buffers: &'d TcpBuffers<N, TX_SZ, RX_SZ>,
-    socket_buffers: NonNull<([u8; TX_SZ], [u8; RX_SZ])>,
+    stack_buffers: &'d dyn DynPool<TcpSocketBuffers>,
+    socket_buffers: Option<TcpSocketBuffers>,
 }
 
-impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpSocket<'d, N, TX_SZ, RX_SZ> {
+impl<'d> TcpSocket<'d> {
     fn new(
         stack: Stack<'d>,
-        stack_buffers: &'d TcpBuffers<N, TX_SZ, RX_SZ>,
+        stack_buffers: &'d dyn DynPool<TcpSocketBuffers>,
     ) -> Result<Self, TcpError> {
-        let mut socket_buffers = stack_buffers.pool.alloc().ok_or(TcpError::NoBuffers)?;
+        let mut socket_buffers = stack_buffers.alloc().ok_or(TcpError::NoBuffers)?;
 
         Ok(Self {
-            socket: unsafe {
-                embassy_net::tcp::TcpSocket::new(
-                    stack,
-                    &mut socket_buffers.as_mut().1,
-                    &mut socket_buffers.as_mut().0,
-                )
-            },
+            socket: embassy_net::tcp::TcpSocket::new(
+                stack,
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.rx_buf.as_mut(),
+                        socket_buffers.rx_buf_len,
+                    )
+                },
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.tx_buf.as_mut(),
+                        socket_buffers.tx_buf_len,
+                    )
+                },
+            ),
             stack_buffers,
-            socket_buffers,
+            socket_buffers: Some(socket_buffers),
         })
     }
 
@@ -165,34 +185,24 @@ impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpSocket<'d, N
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Drop
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl Drop for TcpSocket<'_> {
     fn drop(&mut self) {
-        unsafe {
-            self.socket.close();
-            self.stack_buffers.pool.free(self.socket_buffers);
-        }
+        self.socket.close();
+        self.stack_buffers.free(unwrap!(self.socket_buffers.take()));
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> ErrorType
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl ErrorType for TcpSocket<'_> {
     type Error = TcpError;
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Read
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl Read for TcpSocket<'_> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         Ok(self.socket.read(buf).await?)
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Write
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl Write for TcpSocket<'_> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         Ok(self.socket.write(buf).await?)
     }
@@ -204,18 +214,14 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Write
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Readable
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl Readable for TcpSocket<'_> {
     async fn readable(&mut self) -> Result<(), Self::Error> {
         self.socket.wait_read_ready().await;
         Ok(())
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpShutdown
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl TcpShutdown for TcpSocket<'_> {
     async fn close(&mut self, what: Close) -> Result<(), Self::Error> {
         TcpSocket::close(self, what).await
     }
@@ -225,8 +231,8 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpShutdown
     }
 }
 
-/// Represents the read half of a split TCP socket
-/// Implements the `Read` trait from `embedded-io-async`
+/// A type that represents the read half of a split TCP socket.
+/// Implements the `Read` trait from `embedded-io-async`.
 pub struct TcpSocketRead<'a>(TcpReader<'a>);
 
 impl ErrorType for TcpSocketRead<'_> {
@@ -246,8 +252,8 @@ impl Readable for TcpSocketRead<'_> {
     }
 }
 
-/// Represents the write half of a split TCP socket
-/// Implements the `Write` trait from `embedded-io-async`
+/// A type that represents the write half of a split TCP socket.
+/// Implements the `Write` trait from `embedded-io-async`.
 pub struct TcpSocketWrite<'a>(TcpWriter<'a>);
 
 impl ErrorType for TcpSocketWrite<'_> {
@@ -264,9 +270,7 @@ impl Write for TcpSocketWrite<'_> {
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpSplit
-    for TcpSocket<'_, N, TX_SZ, RX_SZ>
-{
+impl TcpSplit for TcpSocket<'_> {
     type Read<'a>
         = TcpSocketRead<'a>
     where
@@ -284,14 +288,19 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpSplit
     }
 }
 
-/// A shared error type that is used by the TCP factory traits implementation as well as the TCP socket
+/// A shared error type that is used by the TCP factory traits implementation as well as the TCP socket.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TcpError {
+    /// A general TCP error.
     General(Error),
+    /// An error that occurred while connecting.
     Connect(ConnectError),
+    /// An error that occurred while accepting a connection.
     Accept(AcceptError),
+    /// No TCP socket buffers available.
     NoBuffers,
+    /// The provided socket address uses an unsupported protocol.
     UnsupportedProto,
 }
 
@@ -313,7 +322,6 @@ impl From<AcceptError> for TcpError {
     }
 }
 
-// TODO
 impl embedded_io_async::Error for TcpError {
     fn kind(&self) -> ErrorKind {
         match self {
@@ -326,22 +334,52 @@ impl embedded_io_async::Error for TcpError {
     }
 }
 
-/// A struct that holds a pool of TCP buffers
-pub struct TcpBuffers<const N: usize, const TX_SZ: usize, const RX_SZ: usize> {
-    pool: Pool<([u8; TX_SZ], [u8; RX_SZ]), N>,
+/// A type that holds the TCP socket buffers.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TcpSocketBuffers {
+    /// A token used to identify the buffer in the pool.
+    token: NonNull<u8>,
+    /// The buffer for receiving data.
+    rx_buf: NonNull<u8>,
+    /// The buffer for transmitting data.
+    tx_buf: NonNull<u8>,
+    /// The length of the receive buffer.
+    rx_buf_len: usize,
+    /// The length of the transmit buffer.
+    tx_buf_len: usize,
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> Default
+/// A type alias for a pool of TCP socket buffers.
+pub type TcpBuffers<const N: usize, const TX_SZ: usize = 1024, const RX_SZ: usize = 1024> =
+    Pool<([u8; TX_SZ], [u8; RX_SZ]), N>;
+
+impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> SealedDynPool<TcpSocketBuffers>
     for TcpBuffers<N, TX_SZ, RX_SZ>
 {
-    fn default() -> Self {
-        Self::new()
+    fn alloc(&self) -> Option<TcpSocketBuffers> {
+        let mut socket_buffers = Pool::alloc(self)?;
+
+        let rx_buf = unsafe { &mut socket_buffers.as_mut().1 };
+        let tx_buf = unsafe { &mut socket_buffers.as_mut().0 };
+
+        Some(TcpSocketBuffers {
+            token: socket_buffers.cast::<u8>(),
+            rx_buf: unwrap!(NonNull::new(rx_buf.as_mut_ptr())),
+            tx_buf: unwrap!(NonNull::new(tx_buf.as_mut_ptr())),
+            rx_buf_len: rx_buf.len(),
+            tx_buf_len: tx_buf.len(),
+        })
+    }
+
+    fn free(&self, buf: TcpSocketBuffers) {
+        unsafe {
+            Pool::free(self, buf.token.cast::<([u8; TX_SZ], [u8; RX_SZ])>());
+        }
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpBuffers<N, TX_SZ, RX_SZ> {
-    /// Create a new `TcpBuffers` instance
-    pub const fn new() -> Self {
-        Self { pool: Pool::new() }
-    }
+impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize> DynPool<TcpSocketBuffers>
+    for TcpBuffers<N, TX_SZ, RX_SZ>
+{
 }

--- a/edge-nal-embassy/src/udp.rs
+++ b/edge-nal-embassy/src/udp.rs
@@ -8,41 +8,40 @@ use embassy_net::Stack;
 
 use embedded_io_async::{ErrorKind, ErrorType};
 
-use crate::{to_emb_bind_socket, to_emb_socket, to_net_socket, Pool};
+use crate::sealed::SealedDynPool;
+use crate::{to_emb_bind_socket, to_emb_socket, to_net_socket, DynPool, Pool};
 
-/// A struct that implements the `UdpBind` factory trait from `edge-nal`
-/// Capable of managing up to N concurrent connections with TX and RX buffers according to TX_SZ and RX_SZ, and packet metadata according to `M`.
-pub struct Udp<
-    'd,
-    const N: usize,
-    const TX_SZ: usize = 1500,
-    const RX_SZ: usize = 1500,
-    const M: usize = 2,
-> {
+/// A type that implements the `UdpBind` factory trait from `edge-nal`.
+/// Uses the provided Embassy networking stack and UDP buffers pool to create UDP sockets.
+///
+/// The type is `Copy` and `Clone`, so it can be easily passed around.
+#[derive(Copy, Clone)]
+pub struct Udp<'d> {
+    /// The Embassy networking stack to use for creating UDP sockets.
     stack: Stack<'d>,
-    buffers: &'d UdpBuffers<N, TX_SZ, RX_SZ, M>,
+    /// The pool of UDP socket buffers to use for creating UDP sockets.
+    buffers: &'d dyn DynPool<UdpSocketBuffers>,
 }
 
-impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize>
-    Udp<'d, N, TX_SZ, RX_SZ, M>
-{
+impl<'d> Udp<'d> {
     /// Create a new `Udp` instance for the provided Embassy networking stack using the provided UDP buffers.
     ///
-    /// Ensure that the number of buffers `N` fits within StackResources<N> of
-    /// [embassy_net::Stack], while taking into account the sockets used for DHCP, DNS, etc. else
-    /// [smoltcp::iface::SocketSet] will panic with `adding a socket to a full SocketSet`.
-    pub fn new(stack: Stack<'d>, buffers: &'d UdpBuffers<N, TX_SZ, RX_SZ, M>) -> Self {
+    /// # Arguments
+    /// - `stack`: The Embassy networking stack to use for creating UDP sockets.
+    /// - `buffers`: A pool of UDP socket buffers to use for creating UDP sockets.
+    ///   NOTE: Ensure that the number of buffers in the pool is not greater than the number of sockets
+    ///   supported by the provided [embassy_net::Stack], or else [smoltcp::iface::SocketSet] will panic with
+    ///   `adding a socket to a full SocketSet`.
+    pub fn new(stack: Stack<'d>, buffers: &'d dyn DynPool<UdpSocketBuffers>) -> Self {
         Self { stack, buffers }
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpBind
-    for Udp<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpBind for Udp<'_> {
     type Error = UdpError;
 
     type Socket<'a>
-        = UdpSocket<'a, N, TX_SZ, RX_SZ, M>
+        = UdpSocket<'a>
     where
         Self: 'a;
 
@@ -57,66 +56,74 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-/// A UDP socket
-/// Implements the `UdpReceive` `UdpSend` and `UdpSplit` traits from `edge-nal`
-pub struct UdpSocket<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> {
+/// A UDP socket.
+/// Implements the `UdpReceive` `UdpSend` and `UdpSplit` traits from `edge-nal`.
+pub struct UdpSocket<'d> {
+    /// The Embassy networking stack.
     #[allow(unused)]
     stack: embassy_net::Stack<'d>,
+    /// The underlying Embassy UDP socket.
     socket: embassy_net::udp::UdpSocket<'d>,
-    stack_buffers: &'d UdpBuffers<N, TX_SZ, RX_SZ, M>,
-    socket_buffers: NonNull<([u8; TX_SZ], [u8; RX_SZ])>,
-    socket_meta_buffers: NonNull<([PacketMetadata; M], [PacketMetadata; M])>,
+    /// The pool of UDP socket buffers.
+    stack_buffers: &'d dyn DynPool<UdpSocketBuffers>,
+    /// The allocated UDP socket buffers.
+    socket_buffers: Option<UdpSocketBuffers>,
 }
 
-impl<'d, const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize>
-    UdpSocket<'d, N, TX_SZ, RX_SZ, M>
-{
+impl<'d> UdpSocket<'d> {
     fn new(
         stack: Stack<'d>,
-        stack_buffers: &'d UdpBuffers<N, TX_SZ, RX_SZ, M>,
+        stack_buffers: &'d dyn DynPool<UdpSocketBuffers>,
     ) -> Result<Self, UdpError> {
-        let mut socket_buffers = stack_buffers.pool.alloc().ok_or(UdpError::NoBuffers)?;
-        let mut socket_meta_buffers = unwrap!(stack_buffers.meta_pool.alloc());
+        let mut socket_buffers = stack_buffers.alloc().ok_or(UdpError::NoBuffers)?;
 
         Ok(Self {
             stack,
-            socket: unsafe {
-                embassy_net::udp::UdpSocket::new(
-                    stack,
-                    &mut socket_meta_buffers.as_mut().1,
-                    &mut socket_buffers.as_mut().1,
-                    &mut socket_meta_buffers.as_mut().0,
-                    &mut socket_buffers.as_mut().0,
-                )
-            },
+            socket: embassy_net::udp::UdpSocket::new(
+                stack,
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.md_rx_buf.as_mut(),
+                        socket_buffers.md_buf_len,
+                    )
+                },
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.rx_buf.as_mut(),
+                        socket_buffers.rx_buf_len,
+                    )
+                },
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.md_tx_buf.as_mut(),
+                        socket_buffers.md_buf_len,
+                    )
+                },
+                unsafe {
+                    core::slice::from_raw_parts_mut(
+                        socket_buffers.tx_buf.as_mut(),
+                        socket_buffers.tx_buf_len,
+                    )
+                },
+            ),
             stack_buffers,
-            socket_buffers,
-            socket_meta_buffers,
+            socket_buffers: Some(socket_buffers),
         })
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Drop
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl Drop for UdpSocket<'_> {
     fn drop(&mut self) {
-        unsafe {
-            self.socket.close();
-            self.stack_buffers.pool.free(self.socket_buffers);
-            self.stack_buffers.meta_pool.free(self.socket_meta_buffers);
-        }
+        self.socket.close();
+        self.stack_buffers.free(unwrap!(self.socket_buffers.take()));
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> ErrorType
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl ErrorType for UdpSocket<'_> {
     type Error = UdpError;
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpReceive
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpReceive for UdpSocket<'_> {
     async fn receive(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), Self::Error> {
         let (len, remote_endpoint) = self.socket.recv_from(buffer).await?;
 
@@ -124,9 +131,7 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpSend
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpSend for UdpSocket<'_> {
     async fn send(&mut self, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
         self.socket
             .send_to(
@@ -139,15 +144,11 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> ErrorType
-    for &UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl ErrorType for &UdpSocket<'_> {
     type Error = UdpError;
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpReceive
-    for &UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpReceive for &UdpSocket<'_> {
     async fn receive(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), Self::Error> {
         let (len, remote_endpoint) = self.socket.recv_from(buffer).await?;
 
@@ -155,9 +156,7 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpSend
-    for &UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpSend for &UdpSocket<'_> {
     async fn send(&mut self, remote: SocketAddr, data: &[u8]) -> Result<(), Self::Error> {
         self.socket
             .send_to(
@@ -170,18 +169,14 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Readable
-    for &UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl Readable for &UdpSocket<'_> {
     async fn readable(&mut self) -> Result<(), Self::Error> {
         self.socket.wait_recv_ready().await;
         Ok(())
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> UdpSplit
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl UdpSplit for UdpSocket<'_> {
     type Receive<'a>
         = &'a Self
     where
@@ -197,9 +192,7 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Udp
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> MulticastV4
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl MulticastV4 for UdpSocket<'_> {
     async fn join_v4(
         &mut self,
         #[allow(unused)] multicast_addr: Ipv4Addr,
@@ -243,9 +236,7 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Mul
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> MulticastV6
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl MulticastV6 for UdpSocket<'_> {
     async fn join_v6(
         &mut self,
         #[allow(unused)] multicast_addr: Ipv6Addr,
@@ -289,9 +280,7 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Mul
     }
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Readable
-    for UdpSocket<'_, N, TX_SZ, RX_SZ, M>
-{
+impl Readable for UdpSocket<'_> {
     async fn readable(&mut self) -> Result<(), Self::Error> {
         self.socket.wait_recv_ready().await;
         Ok(())
@@ -302,14 +291,19 @@ impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Rea
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum UdpError {
+    /// An error occurred while receiving data.
     Recv(RecvError),
+    /// An error occurred while sending data.
     Send(SendError),
+    /// An error occurred while binding the socket.
     Bind(BindError),
     /// The table of joined multicast groups is already full.
     MulticastGroupTableFull,
     /// Cannot join/leave the given multicast group.
     MulticastUnaddressable,
+    /// No more UDP socket buffers are available.
     NoBuffers,
+    /// The provided protocol is not supported.
     UnsupportedProto,
 }
 
@@ -344,7 +338,6 @@ impl From<embassy_net::MulticastError> for UdpError {
     }
 }
 
-// TODO
 impl embedded_io_async::Error for UdpError {
     fn kind(&self) -> ErrorKind {
         match self {
@@ -359,34 +352,83 @@ impl embedded_io_async::Error for UdpError {
     }
 }
 
-/// A struct that holds a pool of UDP buffers
-pub struct UdpBuffers<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> {
-    pool: Pool<([u8; TX_SZ], [u8; RX_SZ]), N>,
-    meta_pool: Pool<
-        (
-            [embassy_net::udp::PacketMetadata; M],
-            [embassy_net::udp::PacketMetadata; M],
-        ),
-        N,
-    >,
+/// A type that holds the UDP socket buffers.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct UdpSocketBuffers {
+    /// A token used to identify the buffer in the pool.
+    token: NonNull<u8>,
+    /// The metadata buffer for receiving packets.
+    md_rx_buf: NonNull<PacketMetadata>,
+    /// The buffer for receiving packets.
+    rx_buf: NonNull<u8>,
+    /// The metadata buffer for transmitting packets.
+    md_tx_buf: NonNull<PacketMetadata>,
+    /// The buffer for transmitting packets.
+    tx_buf: NonNull<u8>,
+    /// The length of a metadata buffer.
+    md_buf_len: usize,
+    /// The length of the receive buffer.
+    rx_buf_len: usize,
+    /// The length of the transmit buffer.
+    tx_buf_len: usize,
 }
 
-impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize> Default
-    for UdpBuffers<N, TX_SZ, RX_SZ, M>
+/// A type alias for a pool of UDP socket buffers.
+pub type UdpBuffers<
+    const N: usize,
+    const TX_SZ: usize = 1472,
+    const RX_SZ: usize = 1472,
+    const M: usize = 2,
+> = Pool<
+    (
+        [u8; TX_SZ],
+        [u8; RX_SZ],
+        [PacketMetadata; M],
+        [PacketMetadata; M],
+    ),
+    N,
+>;
+
+impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize>
+    SealedDynPool<UdpSocketBuffers> for UdpBuffers<N, TX_SZ, RX_SZ, M>
 {
-    fn default() -> Self {
-        Self::new()
+    fn alloc(&self) -> Option<UdpSocketBuffers> {
+        let mut socket_buffers = Pool::alloc(self)?;
+
+        let rx_buf = unsafe { &mut socket_buffers.as_mut().1 };
+        let tx_buf = unsafe { &mut socket_buffers.as_mut().0 };
+        let md_rx_buf = unsafe { &mut socket_buffers.as_mut().3 };
+        let md_tx_buf = unsafe { &mut socket_buffers.as_mut().2 };
+
+        Some(UdpSocketBuffers {
+            token: socket_buffers.cast::<u8>(),
+            md_rx_buf: unwrap!(NonNull::new(md_rx_buf.as_mut_ptr())),
+            rx_buf: unwrap!(NonNull::new(rx_buf.as_mut_ptr())),
+            md_tx_buf: unwrap!(NonNull::new(md_tx_buf.as_mut_ptr())),
+            tx_buf: unwrap!(NonNull::new(tx_buf.as_mut_ptr())),
+            md_buf_len: md_rx_buf.len(),
+            rx_buf_len: rx_buf.len(),
+            tx_buf_len: tx_buf.len(),
+        })
+    }
+
+    fn free(&self, buf: UdpSocketBuffers) {
+        unsafe {
+            Pool::free(
+                self,
+                buf.token.cast::<(
+                    [u8; TX_SZ],
+                    [u8; RX_SZ],
+                    [PacketMetadata; M],
+                    [PacketMetadata; M],
+                )>(),
+            );
+        }
     }
 }
 
 impl<const N: usize, const TX_SZ: usize, const RX_SZ: usize, const M: usize>
-    UdpBuffers<N, TX_SZ, RX_SZ, M>
+    DynPool<UdpSocketBuffers> for UdpBuffers<N, TX_SZ, RX_SZ, M>
 {
-    /// Create a new `UdpBuffers` instance
-    pub const fn new() -> Self {
-        Self {
-            pool: Pool::new(),
-            meta_pool: Pool::new(),
-        }
-    }
 }

--- a/edge-nal-std/CHANGELOG.md
+++ b/edge-nal-std/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Document the API
+* Make `Stack` `Copy`
 
 ## [0.5.0] - 2025-01-15
 * Updated dependencies for compatibility with `embassy-time-driver` v0.2


### PR DESCRIPTION
The purpose of `edge-nal-embassy` is to provide implementations for the `edge-nal` traits on top of `embassy-net`. 

Therefore, the expectation is that the public struct types of `edge-nal-embassy` for TCP/UDP sockets would rarely be used and instead - the user would write their code against the `edge-nal` traits to achieve platform independence.

Nevertheless - and especially if some of these types need to be put in a static context with embassy's `make_static!` / `mk_static!` macros - the fact that the edge-nal-embassy types are so heavily generified with const generics is inconvenient, as the user has to type the full types, with their `N, TX_SZ, RX_SZ, M` generics.

This PR is erasing all of the const generics (coming from the TCP/UDP buffers' pool) by using not the `Pool` type but rather, a new sealed `DynPool` trait which - furthermore - is injected in the `Tcp`/`Udp` types and their sockets as a `&dyn` trait (hence its own type is also erased).

As a result, `Tcp`/`Udp`/`TcpSocket`/`UdpSocket` have now all their const generics removed and have just a single lifetime generic.

Additionally, `Tcp` , `Udp` and `Dns` are now `Copy` just like the underlying embassy-net `Stack` type for extra user convenience.