### PR TITLE
Update embassy dependencies and remove unused deps

### DIFF
--- a/.github/CI_CHECKLIST.md
+++ b/.github/CI_CHECKLIST.md
@@ -20,12 +20,17 @@ Run clippy with various feature combinations to ensure no warnings:
 
 ```bash
 # Standard features with examples
-cargo clippy --features std,edge-nal-embassy/all --examples --no-deps -- -Dwarnings
+cargo clippy --features std --examples --no-deps -- -Dwarnings
 
 # With defmt feature
-cargo clippy --features std,edge-nal-embassy/all,defmt --no-deps -- -Dwarnings
+cargo clippy --features std,defmt --no-deps -- -Dwarnings
 
 # With log feature and examples
+cargo clippy --features std,log --examples --no-deps -- -Dwarnings
+
+# Embassy / smoltcp checks (Requires Rust 1.91)
+cargo clippy --features std,edge-nal-embassy/all --examples --no-deps -- -Dwarnings
+cargo clippy --features std,edge-nal-embassy/all,defmt --no-deps -- -Dwarnings
 cargo clippy --features std,edge-nal-embassy/all,log --examples --no-deps -- -Dwarnings
 ```
 
@@ -39,7 +44,7 @@ cargo build --features log
 # No default features
 cargo build --no-default-features
 
-# Embassy with defmt
+# Embassy with defmt (Requires Rust 1.91)
 cargo build --no-default-features --features embassy,defmt
 
 # Examples with log
@@ -58,11 +63,12 @@ cargo test --all-features
 
 ## Toolchain Support
 
-CI runs on both:
+CI runs on:
 - **Nightly** Rust
 - **1.88** MSRV (Minimum Supported Rust Version)
+- **1.91** for Embassy / smoltcp checks that require it
 
-Ensure changes are compatible with both versions.
+Ensure each check keeps MSRV compatibility with its specified Rust version.
 
 ## Pre-PR Checklist
 
@@ -71,7 +77,7 @@ Before submitting or updating a PR, verify:
 - [ ] No clippy warnings with all feature combinations
 - [ ] All builds succeed with different feature configurations
 - [ ] All tests pass
-- [ ] Changes are compatible with MSRV (1.88)
+- [ ] Changes are compatible with their specified MSRV
 - [ ] Documentation is updated if needed
 - [ ] Examples are updated or added if needed
 
@@ -84,13 +90,13 @@ To quickly verify your changes locally before pushing:
 cargo fmt -- --check
 
 # Quick clippy check
-cargo clippy --features std,edge-nal-embassy/all --examples --no-deps -- -Dwarnings
+cargo clippy --features std --examples --no-deps -- -Dwarnings
 
 # Quick build check
 cargo build --features log
 
-# Run tests
-cargo test --all-features
+# Embassy test check (Requires Rust 1.91)
+cargo test -p edge-nal-embassy --all-features
 ```
 
 If all these pass, your PR should pass CI successfully.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   compile:
-    name: Compile
+    name: Compile / Rust ${{ matrix.rust_toolchain }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         rust_toolchain:
           - nightly
-          - 1.88 # MSRV
+          - 1.88
 
     steps:
       - name: Setup | Checkout
@@ -35,18 +35,43 @@ jobs:
       - name: Build | Fmt Check
         run: cargo fmt -- --check
       - name: Build | Clippy
+        run: cargo clippy --features std --examples --no-deps -- -Dwarnings
+      - name: Build | Clippy - defmt
+        run: cargo clippy --features std,defmt --no-deps -- -Dwarnings
+      - name: Build | Clippy - log
+        run: cargo clippy --features std,log --examples --no-deps -- -Dwarnings
+      - name: Build | Default
+        run: cargo build --features log
+      - name: Build | Non-default
+        run: cargo build --no-default-features
+      - name: Build | Examples
+        run: cargo build --examples --features log
+      - name: Build | Examples - defmt
+        run: export DEFMT_LOG=trace; cargo check --examples --features std,defmt
+
+  embassy:
+    name: Embassy / Requires Rust 1.91
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.91
+          components: rustfmt, clippy
+      - name: Setup | Std
+        run: rustup component add rust-src --toolchain 1.91-x86_64-unknown-linux-gnu
+      - name: Setup | Set default toolchain
+        run: rustup default 1.91
+      - name: Build | Clippy
         run: cargo clippy --features std,edge-nal-embassy/all --examples --no-deps -- -Dwarnings
       - name: Build | Clippy - defmt
         run: cargo clippy --features std,edge-nal-embassy/all,defmt --no-deps -- -Dwarnings
       - name: Build | Clippy - log
         run: cargo clippy --features std,edge-nal-embassy/all,log --examples --no-deps -- -Dwarnings
-      - name: Build | Default
-        run: cargo build --features log
-      - name: Build | Non-default
-        run: cargo build --no-default-features
       - name: Build | Embassy
         run: cargo build --no-default-features --features embassy,defmt
-      - name: Build | Examples
-        run: cargo build --examples --features log
-      - name: Build | Examples - defmt
-        run: export DEFMT_LOG=trace; cargo check --examples --features std,defmt
+      - name: Test | edge-nal-embassy
+        run: cargo test -p edge-nal-embassy --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ anyhow = "1"
 env_logger = "0.11"
 embedded-io-async = "0.7"
 embassy-time = { version = "0.5", features = ["std", "generic-queue-64"] }
-embassy-sync = "0.7"
+embassy-sync = "0.8"
 embassy-futures = "0.1.2"
 futures-lite = "2"
-rand = "0.9"
+rand = "0.10"
 
 [[example]]
 name = "captive_portal"
@@ -107,13 +107,13 @@ members = [
 
 [workspace.dependencies]
 embassy-futures = { version = "0.1.2", default-features = false }
-embassy-sync = { version = "0.7", default-features = false }
+embassy-sync = { version = "0.8", default-features = false }
 embassy-time = { version = "0.5", default-features = false }
 embedded-io-async = { version = "0.7", default-features = false }
-embassy-net = { version = "0.8", default-features = false }
+embassy-net = { version = "0.9", default-features = false }
 heapless = { version = "0.9", default-features = false }
 domain = { version = "0.11", default-features = false, features = ["heapless"] }
-rand_core = { version = "0.9", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 num_enum = { version = "0.7", default-features = false }
 httparse = { version = "1.10", default-features = false }
 base64 = { version = "0.22", default-features = false }

--- a/edge-dhcp/CHANGELOG.md
+++ b/edge-dhcp/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Update the `rand_core` dependency to 0.10
+
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` and `edge-raw` dependencies
 * Update the `rand_core` dependency

--- a/edge-dhcp/src/client.rs
+++ b/edge-dhcp/src/client.rs
@@ -1,4 +1,4 @@
-use rand_core::RngCore;
+use rand_core::Rng;
 
 use super::*;
 
@@ -14,7 +14,7 @@ pub struct Client<T> {
 
 impl<T> Client<T>
 where
-    T: RngCore,
+    T: Rng,
 {
     pub const fn new(rng: T, mac: [u8; 6]) -> Self {
         Self { rng, mac }

--- a/edge-dhcp/src/io/client.rs
+++ b/edge-dhcp/src/io/client.rs
@@ -5,7 +5,7 @@ use edge_nal::{UdpReceive, UdpSend};
 use embassy_futures::select::{select, Either};
 use embassy_time::{Duration, Instant, Timer};
 
-use rand_core::RngCore;
+use rand_core::Rng;
 
 pub use super::*;
 
@@ -49,7 +49,7 @@ impl Lease {
         buf: &'a mut [u8],
     ) -> Result<(Self, NetworkInfo<'a>), Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         loop {
@@ -106,7 +106,7 @@ impl Lease {
         buf: &mut [u8],
     ) -> Result<(), Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         loop {
@@ -133,7 +133,7 @@ impl Lease {
         buf: &mut [u8],
     ) -> Result<bool, Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         info!("Renewing DHCP lease...");
@@ -170,7 +170,7 @@ impl Lease {
         buf: &mut [u8],
     ) -> Result<(), Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         let mut opt_buf = Options::buf();
@@ -194,7 +194,7 @@ impl Lease {
         timeout: Duration,
     ) -> Result<Settings<'a>, Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         info!("Discovering DHCP servers...");
@@ -253,7 +253,7 @@ impl Lease {
         retries: usize,
     ) -> Result<Option<Settings<'a>>, Error<S::Error>>
     where
-        T: RngCore,
+        T: Rng,
         S: UdpReceive + UdpSend,
     {
         for _ in 0..retries {

--- a/edge-http/CHANGELOG.md
+++ b/edge-http/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Update the `embassy-sync` dependency to 0.8
+* Remove the unused `embassy-time` dependency
+
 ## [0.7.0] - 2026-01-01
 * Update the `embedded-io-async` and `edge-nal` dependencies
 * Remove the `embedded-svc` feature

--- a/edge-http/Cargo.toml
+++ b/edge-http/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
 [features]
 default = ["io"]
 std = ["io"]
-io = ["embedded-io-async", "edge-nal", "embassy-sync", "embassy-futures", "embassy-time"]
+io = ["embedded-io-async", "edge-nal", "embassy-sync", "embassy-futures"]
 defmt = ["dep:defmt", "heapless/defmt"]
 
 [dependencies]
@@ -32,4 +32,3 @@ base64 = { workspace = true, default-features = false }
 sha1_smol = { workspace = true, default-features = false }
 embassy-sync = { workspace = true, optional = true }
 embassy-futures = { workspace = true, optional = true }
-embassy-time = { workspace = true, optional = true }

--- a/edge-mdns/CHANGELOG.md
+++ b/edge-mdns/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Update the `rand_core` dependency to 0.10
+
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` and `embassy-time` dependencies
 * Update the `domain` dependency to 0.11

--- a/edge-mdns/src/io.rs
+++ b/edge-mdns/src/io.rs
@@ -163,7 +163,7 @@ where
     S: UdpSend<Error = R::Error>,
     RB: BufferAccess<[u8]>,
     SB: BufferAccess<[u8]>,
-    C: rand_core::RngCore,
+    C: rand_core::Rng,
     M: RawMutex,
 {
     /// Creates a new mDNS service with the provided handler, interfaces, and UDP receiver and sender.

--- a/edge-nal-embassy/CHANGELOG.md
+++ b/edge-nal-embassy/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Update to `embassy-net` 0.9
+* Remove the unused `heapless` dependency
+* Raise MSRV to 1.91 to compile `smoltcp`
+
 ## [0.8.0] - 2026-01-01
 * Update the `edge-nal` and `embedded-io-async` dependencies
 

--- a/edge-nal-embassy/Cargo.toml
+++ b/edge-nal-embassy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "edge-nal-embassy"
 version = "0.8.1"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.91"
 description = "An implementation of edge-nal based on `embassy-net`"
 repository = "https://github.com/ivmarkov/edge-net"
 readme = "README.md"
@@ -17,7 +17,7 @@ categories = [
 [features]
 default = ["all"]
 all = ["proto-ipv4", "proto-ipv6", "medium-ethernet", "medium-ip", "dns", "udp", "tcp", "multicast", "icmp", "dhcpv4", "dhcpv4-hostname"]
-defmt = ["dep:defmt", "heapless/defmt", "embassy-net/defmt"]
+defmt = ["dep:defmt", "embassy-net/defmt"]
 proto-ipv4 = ["embassy-net/proto-ipv4"]
 proto-ipv6 = ["embassy-net/proto-ipv6"]
 medium-ethernet = ["embassy-net/medium-ethernet"]
@@ -35,6 +35,5 @@ log = { workspace = true, default-features = false, optional = true }
 defmt = { workspace = true, default-features = false, optional = true }
 embedded-io-async = { workspace = true }
 edge-nal = { workspace = true }
-heapless = { workspace = true }
 embassy-net = { workspace = true }
 embassy-futures = { workspace = true }

--- a/edge-nal-std/CHANGELOG.md
+++ b/edge-nal-std/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Remove the unused `heapless` and `log` dependencies
+
 ## [0.6.0] - 2026-01-01
 * Update the `edge-nal` and `embedded-io-async` dependencies
 * Use `async-io-mini` from `crates.io`

--- a/edge-nal-std/Cargo.toml
+++ b/edge-nal-std/Cargo.toml
@@ -15,10 +15,8 @@ categories = [
 ]
 
 [dependencies]
-log = { workspace = true, default-features = true }
 embedded-io-async = { workspace = true, features = ["std"] }
 edge-nal = { workspace = true }
-heapless = { workspace = true }
 async-io = "2"
 async-io-mini = { version = "0.4", optional = true }
 futures-lite = "2"

--- a/examples/ws_client.rs
+++ b/examples/ws_client.rs
@@ -7,7 +7,7 @@ use edge_http::ws::{MAX_BASE64_KEY_LEN, MAX_BASE64_KEY_RESPONSE_LEN, NONCE_LEN};
 use edge_nal::{AddrType, Dns, TcpConnect};
 use edge_ws::{FrameHeader, FrameType};
 
-use rand::RngCore;
+use rand::Rng;
 
 use log::*;
 


### PR DESCRIPTION
- Bump `rand` and `rand_core` to 0.10
- Remove unused `heapless` and `log` from `edge-nal-std`
- Remove unused `heapless` from `edge-nal-embassy`
- Remove unused `embassy-time` from `edge-net`
- Bump MSVR of `edge-nal-embassy` to 1.91 to be compatible with `smoltcp`
- Keep building on 1.88 for existing crates and only check `edge-nal-embassy` with Rust 1.91 to be compatible with `smoltcp`.