### PR TITLE
New trait: UdpSplitMulticast

### DIFF
--- a/edge-captive/CHANGELOG.md
+++ b/edge-captive/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Breaking: update the `edge-nal` dependency
+
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` dependency
 

--- a/edge-dhcp/CHANGELOG.md
+++ b/edge-dhcp/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Update the `rand_core` dependency to 0.10
+* Breaking: update the `edge-nal` dependency
+* Breaking: update the `rand_core` dependency to 0.10
 
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` and `edge-raw` dependencies

--- a/edge-http/CHANGELOG.md
+++ b/edge-http/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Breaking: update the `edge-nal` dependency
 * Update the `embassy-sync` dependency to 0.8
 * Remove the unused `embassy-time` dependency
 

--- a/edge-http/src/io/server.rs
+++ b/edge-http/src/io/server.rs
@@ -849,10 +849,9 @@ impl<const P: usize, const B: usize, const N: usize> Server<P, B, N> {
             Q, P, Q
         );
 
-        for acceptor_id in 0..Q {
+        for (acceptor_id, signal) in accept_signals.iter().enumerate() {
             let acceptor = &acceptor;
             let socket_queue = &socket_queue;
-            let signal = &accept_signals[acceptor_id];
 
             unwrap!(acceptor_tasks
                 .push(async move {

--- a/edge-http/src/lib.rs
+++ b/edge-http/src/lib.rs
@@ -645,13 +645,11 @@ impl BodyType {
                             Err(HeadersMismatchError::BodyTypeError("Raw body response with a Keep-Alive connection. This is not allowed."))?;
                         }
                     }
-                    BodyType::Chunked => {
-                        if !http11 {
-                            warn!("Chunked body with an HTTP/1.0 connection. This is not allowed.");
-                            Err(HeadersMismatchError::BodyTypeError(
-                                "Chunked body with an HTTP/1.0 connection. This is not allowed.",
-                            ))?;
-                        }
+                    BodyType::Chunked if !http11 => {
+                        warn!("Chunked body with an HTTP/1.0 connection. This is not allowed.");
+                        Err(HeadersMismatchError::BodyTypeError(
+                            "Chunked body with an HTTP/1.0 connection. This is not allowed.",
+                        ))?;
                     }
                     _ => {}
                 }

--- a/edge-mdns/CHANGELOG.md
+++ b/edge-mdns/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Update the `rand_core` dependency to 0.10
+* Breaking: update the `edge-nal` dependency
+* Breaking: update the `rand_core` dependency to 0.10
 
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` and `embassy-time` dependencies

--- a/edge-mdns/src/io.rs
+++ b/edge-mdns/src/io.rs
@@ -387,18 +387,9 @@ where
         for remote_addr in
             core::iter::once(SocketAddr::V4(SocketAddrV4::new(IP_BROADCAST_ADDR, PORT)))
                 .filter(|_| self.ipv4_interface.is_some())
-                .chain(
-                    self.ipv6_interface
-                        .map(|interface| {
-                            SocketAddr::V6(SocketAddrV6::new(
-                                IPV6_BROADCAST_ADDR,
-                                PORT,
-                                0,
-                                interface,
-                            ))
-                        })
-                        .into_iter(),
-                )
+                .chain(self.ipv6_interface.map(|interface| {
+                    SocketAddr::V6(SocketAddrV6::new(IPV6_BROADCAST_ADDR, PORT, 0, interface))
+                }))
         {
             if !data.is_empty() {
                 debug!("Broadcasting mDNS entry to {}", remote_addr);

--- a/edge-nal-embassy/CHANGELOG.md
+++ b/edge-nal-embassy/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Breaking: new trait: `UdpSplitMulticast` which is now required on the socket provided by `UdpBind` and `UdpConnect`
 * Update to `embassy-net` 0.9
 * Remove the unused `heapless` dependency
 * Raise MSRV to 1.91 to compile `smoltcp`

--- a/edge-nal-embassy/src/udp.rs
+++ b/edge-nal-embassy/src/udp.rs
@@ -2,7 +2,9 @@ use core::fmt::Display;
 use core::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use core::ptr::NonNull;
 
-use edge_nal::{MulticastV4, MulticastV6, Readable, UdpBind, UdpReceive, UdpSend, UdpSplit};
+use edge_nal::{
+    MulticastV4, MulticastV6, Readable, UdpBind, UdpReceive, UdpSend, UdpSplit, UdpSplitMulticast,
+};
 
 use embassy_net::udp::{BindError, PacketMetadata, RecvError, SendError};
 use embassy_net::Stack;
@@ -111,6 +113,90 @@ impl<'d> UdpSocket<'d> {
             buffer_token: socket_buffers.token,
         })
     }
+
+    async fn join_v4(
+        &self,
+        #[allow(unused)] multicast_addr: Ipv4Addr,
+        _interface: Ipv4Addr,
+    ) -> Result<(), UdpError> {
+        #[cfg(feature = "multicast")]
+        {
+            self.stack.join_multicast_group(
+                crate::to_emb_addr(core::net::IpAddr::V4(multicast_addr))
+                    .ok_or(UdpError::UnsupportedProto)?,
+            )?;
+        }
+
+        #[cfg(not(feature = "multicast"))]
+        {
+            Err(UdpError::UnsupportedProto)?;
+        }
+
+        Ok(())
+    }
+
+    async fn leave_v4(
+        &self,
+        #[allow(unused)] multicast_addr: Ipv4Addr,
+        _interface: Ipv4Addr,
+    ) -> Result<(), UdpError> {
+        #[cfg(feature = "multicast")]
+        {
+            self.stack.leave_multicast_group(
+                crate::to_emb_addr(core::net::IpAddr::V4(multicast_addr))
+                    .ok_or(UdpError::UnsupportedProto)?,
+            )?;
+        }
+
+        #[cfg(not(feature = "multicast"))]
+        {
+            Err(UdpError::UnsupportedProto)?;
+        }
+
+        Ok(())
+    }
+
+    async fn join_v6(
+        &self,
+        #[allow(unused)] multicast_addr: Ipv6Addr,
+        _interface: u32,
+    ) -> Result<(), UdpError> {
+        #[cfg(feature = "multicast")]
+        {
+            self.stack.join_multicast_group(
+                crate::to_emb_addr(core::net::IpAddr::V6(multicast_addr))
+                    .ok_or(UdpError::UnsupportedProto)?,
+            )?;
+        }
+
+        #[cfg(not(feature = "multicast"))]
+        {
+            Err(UdpError::UnsupportedProto)?;
+        }
+
+        Ok(())
+    }
+
+    async fn leave_v6(
+        &self,
+        #[allow(unused)] multicast_addr: Ipv6Addr,
+        _interface: u32,
+    ) -> Result<(), UdpError> {
+        #[cfg(feature = "multicast")]
+        {
+            self.stack.leave_multicast_group(
+                crate::to_emb_addr(core::net::IpAddr::V6(multicast_addr))
+                    .ok_or(UdpError::UnsupportedProto)?,
+            )?;
+        }
+
+        #[cfg(not(feature = "multicast"))]
+        {
+            Err(UdpError::UnsupportedProto)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for UdpSocket<'_> {
@@ -195,91 +281,98 @@ impl UdpSplit for UdpSocket<'_> {
     }
 }
 
+impl<'d> UdpSplitMulticast for UdpSocket<'d> {
+    type MulticastV4<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    type MulticastV6<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    fn split_multicast(
+        &mut self,
+    ) -> (
+        Self::Receive<'_>,
+        Self::Send<'_>,
+        Self::MulticastV4<'_>,
+        Self::MulticastV6<'_>,
+    ) {
+        (&*self, &*self, &*self, &*self)
+    }
+}
+
 impl MulticastV4 for UdpSocket<'_> {
     async fn join_v4(
         &mut self,
-        #[allow(unused)] multicast_addr: Ipv4Addr,
-        _interface: Ipv4Addr,
+        multicast_addr: Ipv4Addr,
+        interface: Ipv4Addr,
     ) -> Result<(), Self::Error> {
-        #[cfg(feature = "multicast")]
-        {
-            self.stack.join_multicast_group(
-                crate::to_emb_addr(core::net::IpAddr::V4(multicast_addr))
-                    .ok_or(UdpError::UnsupportedProto)?,
-            )?;
-        }
-
-        #[cfg(not(feature = "multicast"))]
-        {
-            Err(UdpError::UnsupportedProto)?;
-        }
-
-        Ok(())
+        Self::join_v4(self, multicast_addr, interface).await
     }
 
     async fn leave_v4(
         &mut self,
-        #[allow(unused)] multicast_addr: Ipv4Addr,
-        _interface: Ipv4Addr,
+        multicast_addr: Ipv4Addr,
+        interface: Ipv4Addr,
     ) -> Result<(), Self::Error> {
-        #[cfg(feature = "multicast")]
-        {
-            self.stack.leave_multicast_group(
-                crate::to_emb_addr(core::net::IpAddr::V4(multicast_addr))
-                    .ok_or(UdpError::UnsupportedProto)?,
-            )?;
-        }
+        Self::leave_v4(self, multicast_addr, interface).await
+    }
+}
 
-        #[cfg(not(feature = "multicast"))]
-        {
-            Err(UdpError::UnsupportedProto)?;
-        }
+impl MulticastV4 for &UdpSocket<'_> {
+    async fn join_v4(
+        &mut self,
+        multicast_addr: Ipv4Addr,
+        interface: Ipv4Addr,
+    ) -> Result<(), Self::Error> {
+        UdpSocket::join_v4(self, multicast_addr, interface).await
+    }
 
-        Ok(())
+    async fn leave_v4(
+        &mut self,
+        multicast_addr: Ipv4Addr,
+        interface: Ipv4Addr,
+    ) -> Result<(), Self::Error> {
+        UdpSocket::leave_v4(self, multicast_addr, interface).await
     }
 }
 
 impl MulticastV6 for UdpSocket<'_> {
     async fn join_v6(
         &mut self,
-        #[allow(unused)] multicast_addr: Ipv6Addr,
-        _interface: u32,
+        multicast_addr: Ipv6Addr,
+        interface: u32,
     ) -> Result<(), Self::Error> {
-        #[cfg(feature = "multicast")]
-        {
-            self.stack.join_multicast_group(
-                crate::to_emb_addr(core::net::IpAddr::V6(multicast_addr))
-                    .ok_or(UdpError::UnsupportedProto)?,
-            )?;
-        }
-
-        #[cfg(not(feature = "multicast"))]
-        {
-            Err(UdpError::UnsupportedProto)?;
-        }
-
-        Ok(())
+        Self::join_v6(self, multicast_addr, interface).await
     }
 
     async fn leave_v6(
         &mut self,
-        #[allow(unused)] multicast_addr: Ipv6Addr,
-        _interface: u32,
+        multicast_addr: Ipv6Addr,
+        interface: u32,
     ) -> Result<(), Self::Error> {
-        #[cfg(feature = "multicast")]
-        {
-            self.stack.leave_multicast_group(
-                crate::to_emb_addr(core::net::IpAddr::V6(multicast_addr))
-                    .ok_or(UdpError::UnsupportedProto)?,
-            )?;
-        }
+        Self::leave_v6(self, multicast_addr, interface).await
+    }
+}
 
-        #[cfg(not(feature = "multicast"))]
-        {
-            Err(UdpError::UnsupportedProto)?;
-        }
+impl MulticastV6 for &UdpSocket<'_> {
+    async fn join_v6(
+        &mut self,
+        multicast_addr: Ipv6Addr,
+        interface: u32,
+    ) -> Result<(), Self::Error> {
+        UdpSocket::join_v6(self, multicast_addr, interface).await
+    }
 
-        Ok(())
+    async fn leave_v6(
+        &mut self,
+        multicast_addr: Ipv6Addr,
+        interface: u32,
+    ) -> Result<(), Self::Error> {
+        UdpSocket::leave_v6(self, multicast_addr, interface).await
     }
 }
 

--- a/edge-nal-openthread/CHANGELOG.md
+++ b/edge-nal-openthread/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+* Initial release

--- a/edge-nal-openthread/src/lib.rs
+++ b/edge-nal-openthread/src/lib.rs
@@ -203,6 +203,29 @@ impl edge_nal::UdpSplit for OtUdpSocket<'_> {
     }
 }
 
+impl edge_nal::UdpSplitMulticast for OtUdpSocket<'_> {
+    type MulticastV4<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    type MulticastV6<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    fn split_multicast(
+        &mut self,
+    ) -> (
+        Self::Receive<'_>,
+        Self::Send<'_>,
+        Self::MulticastV4<'_>,
+        Self::MulticastV6<'_>,
+    ) {
+        (&*self, &*self, &*self, &*self)
+    }
+}
+
 impl edge_nal::io::ErrorType for &OtUdpSocket<'_> {
     type Error = OtNalError;
 }

--- a/edge-nal-std/CHANGELOG.md
+++ b/edge-nal-std/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Breaking: new trait: `UdpSplitMulticast` which is now required on the socket provided by `UdpBind` and `UdpConnect`
 * Remove the unused `heapless` and `log` dependencies
 
 ## [0.6.0] - 2026-01-01

--- a/edge-nal-std/src/lib.rs
+++ b/edge-nal-std/src/lib.rs
@@ -21,7 +21,7 @@ use embedded_io_async::{ErrorType, Read, Write};
 
 use edge_nal::{
     AddrType, Dns, MulticastV4, MulticastV6, Readable, TcpAccept, TcpBind, TcpConnect, TcpShutdown,
-    TcpSplit, UdpBind, UdpConnect, UdpReceive, UdpSend, UdpSplit,
+    TcpSplit, UdpBind, UdpConnect, UdpReceive, UdpSend, UdpSplit, UdpSplitMulticast,
 };
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -573,6 +573,31 @@ impl UdpSplit for UdpSocket {
         let socket = &*self;
 
         (socket, socket)
+    }
+}
+
+impl UdpSplitMulticast for UdpSocket {
+    type MulticastV4<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    type MulticastV6<'a>
+        = &'a Self
+    where
+        Self: 'a;
+
+    fn split_multicast(
+        &mut self,
+    ) -> (
+        Self::Receive<'_>,
+        Self::Send<'_>,
+        Self::MulticastV4<'_>,
+        Self::MulticastV6<'_>,
+    ) {
+        let socket = &*self;
+
+        (socket, socket, socket, socket)
     }
 }
 

--- a/edge-nal-tls/CHANGELOG.md
+++ b/edge-nal-tls/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+* Initial release

--- a/edge-nal/CHANGELOG.md
+++ b/edge-nal/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Breaking: new trait: `UdpSplitMulticast` which is now required on the socket provided by `UdpBind` and `UdpConnect`
+
 ## [0.6.0] - 2026-01-01
 * Update the `embedded-io-async` and `embassy-time` dependencies
 

--- a/edge-nal/src/stack/udp.rs
+++ b/edge-nal/src/stack/udp.rs
@@ -39,7 +39,7 @@ where
 }
 
 /// This trait is implemented by UDP sockets that can be split into separate
-/// `send`, `receive`, multicastv4, and multicastv6 parts that can operate independently from each other
+/// `receive`, `send`, `MulticastV4`, and `MulticastV6` parts that can operate independently from each other
 /// (i.e., a full-duplex connection with multicasting capabilities)
 pub trait UdpSplitMulticast: UdpSplit {
     type MulticastV4<'a>: MulticastV4<Error = Self::Error>

--- a/edge-nal/src/stack/udp.rs
+++ b/edge-nal/src/stack/udp.rs
@@ -38,6 +38,52 @@ where
     }
 }
 
+/// This trait is implemented by UDP sockets that can be split into separate
+/// `send`, `receive`, multicastv4, and multicastv6 parts that can operate independently from each other
+/// (i.e., a full-duplex connection with multicasting capabilities)
+pub trait UdpSplitMulticast: UdpSplit {
+    type MulticastV4<'a>: MulticastV4<Error = Self::Error>
+    where
+        Self: 'a;
+    type MulticastV6<'a>: MulticastV6<Error = Self::Error>
+    where
+        Self: 'a;
+
+    fn split_multicast(
+        &mut self,
+    ) -> (
+        Self::Receive<'_>,
+        Self::Send<'_>,
+        Self::MulticastV4<'_>,
+        Self::MulticastV6<'_>,
+    );
+}
+
+impl<T> UdpSplitMulticast for &mut T
+where
+    T: UdpSplitMulticast,
+{
+    type MulticastV4<'a>
+        = T::MulticastV4<'a>
+    where
+        Self: 'a;
+    type MulticastV6<'a>
+        = T::MulticastV6<'a>
+    where
+        Self: 'a;
+
+    fn split_multicast(
+        &mut self,
+    ) -> (
+        Self::Receive<'_>,
+        Self::Send<'_>,
+        Self::MulticastV4<'_>,
+        Self::MulticastV6<'_>,
+    ) {
+        (**self).split_multicast()
+    }
+}
+
 /// This is a factory trait for creating connected UDP sockets
 pub trait UdpConnect {
     /// Error type returned on socket creation failure
@@ -46,7 +92,7 @@ pub trait UdpConnect {
     /// The socket type returned by the factory
     type Socket<'a>: UdpReceive<Error = Self::Error>
         + UdpSend<Error = Self::Error>
-        + UdpSplit<Error = Self::Error>
+        + UdpSplitMulticast<Error = Self::Error>
         + MulticastV4<Error = Self::Error>
         + MulticastV6<Error = Self::Error>
         + Readable<Error = Self::Error>
@@ -69,7 +115,7 @@ pub trait UdpBind {
     /// The socket type returned by the stack
     type Socket<'a>: UdpReceive<Error = Self::Error>
         + UdpSend<Error = Self::Error>
-        + UdpSplit<Error = Self::Error>
+        + UdpSplitMulticast<Error = Self::Error>
         + MulticastV4<Error = Self::Error>
         + MulticastV6<Error = Self::Error>
         + Readable<Error = Self::Error>

--- a/edge-raw/CHANGELOG.md
+++ b/edge-raw/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Breaking: update the `edge-nal` dependency
+
 ## [0.7.0] - 2026-01-01
 * Update the `edge-nal` and `embedded-io-async` dependencies
 

--- a/edge-ws/CHANGELOG.md
+++ b/edge-ws/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Breaking: update the `edge-nal` dependency
+
 ## [0.7.0] - 2026-01-01
 * Update the `embedded-io-async` dependency
 * Remove the `embedded-svc` feature


### PR DESCRIPTION
Now that `rs-matter` had gained Groups support, [we do need a way to join/leave Ipv6 multicast groups on a split-socket](https://github.com/sysgrok/rs-matter-stack/blob/27dc6aedf3218cc7a7d2a72402082ccacb53ec0a/src/lib.rs#L608).

While for mDNS this was not necessary, as the socket can join the mDNS multicast group _before_ it is split, the `rs-matter` groups' functionality demands dynamic multicast group join/leave **while the socket is already split into a read + write halves and operating as such**.

So in a way we need a new type of socket split that either:
- Still splits into a read + write halves, but the write half is not just `UdpSend` but also `MulticastV4` and `MulticastV6`
- Or splits into (read, write, multicastv4, multicastv6) tuple

This PR implements the second approach, though for rs-matter specifically the first approach would work too.